### PR TITLE
Thompson branch

### DIFF
--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -257,23 +257,17 @@ export async function confirmReaction(
          * Temporary Nitro Solution
          * Check if user who reacted to Nitro has the server booster role
          */
-
         if(mapKey === "NITRO"){
 
             //Obtain Nitro role id if present on server
-            let nitroRoleID = ""; //To test on Test Server, initialize nitroRoleID to a role on the server.
-            if(interaction.guild.roles.premiumSubscriberRole?.id){
-                nitroRoleID = interaction.guild.roles.premiumSubscriberRole.id;
-            }
-
-            //If Nitro role is null or member does not have role corresponding to nitroRoleID, return null
-            if(nitroRoleID === "" || !member.roles.cache.find(role => role.id === nitroRoleID)){
-
+            //To test on Test Server, change "" to a role on the server.
+            const nitroRoleID = interaction.guild.roles.premiumSubscriberRole?.id ?? ""; 
+            if(!member.roles.cache.has(nitroRoleID)){
                 await interaction.reply({
                     ephemeral: true,
                     content: "No Nitro",
                 });
-                return null
+                return null;
             }
         }
 

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -460,7 +460,12 @@ export function controlPanelCollectorFilter(guildDoc: IGuildInfo, section: ISect
             guildDoc.roles.staffRoles.universalLeaderRoleIds.headLeaderRoleId,
             guildDoc.roles.staffRoles.universalLeaderRoleIds.leaderRoleId,
             guildDoc.roles.staffRoles.universalLeaderRoleIds.almostLeaderRoleId,
-            guildDoc.roles.staffRoles.universalLeaderRoleIds.vetLeaderRoleId
+            guildDoc.roles.staffRoles.universalLeaderRoleIds.vetLeaderRoleId,
+
+            // Moderation team roles
+            guildDoc.roles.staffRoles.moderation.moderatorRoleId,
+            guildDoc.roles.staffRoles.moderation.officerRoleId,
+            guildDoc.roles.staffRoles.moderation.securityRoleId
         ];
 
         const customPermData = guildDoc.properties.customCmdPermissions

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -261,7 +261,7 @@ export async function confirmReaction(
         if(mapKey === "NITRO"){
 
             //Obtain Nitro role id if present on server
-            var nitroRoleID = ""; //To test on Test Server, initialize nitroRoleID to a role on the server.
+            let nitroRoleID = ""; //To test on Test Server, initialize nitroRoleID to a role on the server.
             if(interaction.guild.roles.premiumSubscriberRole?.id){
                 nitroRoleID = interaction.guild.roles.premiumSubscriberRole.id;
             }
@@ -488,9 +488,10 @@ export function controlPanelCollectorFilter(guildDoc: IGuildInfo, section: ISect
             guildDoc.roles.staffRoles.universalLeaderRoleIds.vetLeaderRoleId,
 
             // Moderation team roles
-            guildDoc.roles.staffRoles.moderation.moderatorRoleId,
-            guildDoc.roles.staffRoles.moderation.officerRoleId,
-            guildDoc.roles.staffRoles.moderation.securityRoleId
+            guildDoc.roles.staffRoles.moderation.helperRoleId,
+            guildDoc.roles.staffRoles.moderation.securityRoleId,
+            guildDoc.roles.staffRoles.moderation.officerRoleId,            
+            guildDoc.roles.staffRoles.moderation.moderatorRoleId
         ];
 
         const customPermData = guildDoc.properties.customCmdPermissions

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -252,6 +252,31 @@ export async function confirmReaction(
         .appendLine(2);
 
     if (reactInfo.type === "EARLY_LOCATION") {
+        
+        /**
+         * Temporary Nitro Solution
+         * Check if user who reacted to Nitro has the server booster role
+         */
+
+        if(mapKey === "NITRO"){
+
+            //Obtain Nitro role id if present on server
+            var nitroRoleID = ""; //To test on Test Server, initialize nitroRoleID to a role on the server.
+            if(interaction.guild.roles.premiumSubscriberRole?.id){
+                nitroRoleID = interaction.guild.roles.premiumSubscriberRole.id;
+            }
+
+            //If Nitro role is null or member does not have role corresponding to nitroRoleID, return null
+            if(nitroRoleID === "" || !member.roles.cache.find(role => role.id === nitroRoleID)){
+
+                await interaction.reply({
+                    ephemeral: true,
+                    content: "No Nitro",
+                });
+                return null
+            }
+        }
+
         contentDisplay
             .append("Please confirm that you want to receive early location/priority queueing. You have **15** seconds")
             .append(" to select an option. Failure to respond will result in an automatic **no**.")

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -1990,8 +1990,8 @@ export class RaidInstance {
             this._pplConfirmingReaction.delete(i.user.id);
             if (!res) {
                 await i.editReply({
-                    content: "You either did not respond to a question that was asked, or chose to cancel this"
-                        + ` process. Either way, the preference (${itemDis}) that you selected has **not** been logged`
+                    content: "You either timed out, chose to cancel, or did not have Nitro."
+                        + ` The preference (${itemDis}) that you selected has **not** been logged`
                         + " with the raid leader.",
                     components: []
                 });

--- a/src/instances/RaidInstance.ts
+++ b/src/instances/RaidInstance.ts
@@ -2219,6 +2219,7 @@ export class RaidInstance {
 
         member.voice.setChannel(this._raidVc).catch();
         this.logEvent(`${member.displayName} (${member.id}) has reconnected to the raid VC.`, true).catch();
+        return;
     }
 
     /**


### PR DESCRIPTION
3 Issues addressed.

1. Return statement added to prevent crashes when raiders rejoin vc
2. Moderators should now have access to control panels.
3. Nitro reacts should only work for users with Nitro***

*** This requires testing with users that DO and DO NOT have Nitro.  I attempted to avoid a hard-coded solution that would be specific to Dungeoneer, but can't test without nitro.