### PR TITLE
Refactored Headcount/Afkcheck using common methods

### DIFF
--- a/src/commands/raid-leaders/StartAfkCheck.ts
+++ b/src/commands/raid-leaders/StartAfkCheck.ts
@@ -3,7 +3,7 @@ import {MongoManager} from "../../managers/MongoManager";
 import {RaidInstance} from "../../instances/RaidInstance";
 import {SlashCommandBuilder} from "@discordjs/builders";
 import {DungeonUtilities} from "../../utilities/DungeonUtilities";
-import {getAvailableSections, DungeonSelectionType, getSelectedSection, getSelectedDungeon} from "../../instances/Common";
+import {getAvailableSections, DungeonSelectionType, getSelectedSection, getSelectedDungeon} from "./common/RaidLeaderCommon";
 
 export class StartAfkCheck extends BaseCommand {
     public static readonly START_AFK_CMD_CODE: string = "AFK_CHECK_START";

--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -1,31 +1,8 @@
 import {BaseCommand, ICommandContext} from "../BaseCommand";
 import {MongoManager} from "../../managers/MongoManager";
-import {IDungeonInfo, ISectionInfo} from "../../definitions";
-import {
-    MessageActionRow,
-    MessageSelectMenu,
-    Role,
-    TextChannel
-} from "discord.js";
-import {GuildFgrUtilities} from "../../utilities/fetch-get-request/GuildFgrUtilities";
-import {DUNGEON_DATA} from "../../constants/dungeons/DungeonData";
-import {AdvancedCollector} from "../../utilities/collectors/AdvancedCollector";
-import {StringUtil} from "../../utilities/StringUtilities";
-import {ArrayUtilities} from "../../utilities/ArrayUtilities";
-import {MessageUtilities} from "../../utilities/MessageUtilities";
 import {DungeonUtilities} from "../../utilities/DungeonUtilities";
-import {canManageRaidsIn, hasPermsToRaid} from "../../instances/Common";
+import {getAvailableSections, DungeonSelectionType, getSelectedSection, getSelectedDungeon} from "../../instances/Common";
 import {HeadcountInstance} from "../../instances/HeadcountInstance";
-import {ButtonConstants} from "../../constants/ButtonConstants";
-
-type DungeonSelectionType = {
-    section: ISectionInfo;
-    afkCheckChan: TextChannel;
-    cpChan: TextChannel;
-    raiderRole: Role;
-    dungeons: IDungeonInfo[];
-    omittedDungeons: IDungeonInfo[];
-};
 
 export class StartHeadcount extends BaseCommand {
     public static readonly START_HC_CMD_CODE: string = "HEADCOUNT_START";
@@ -54,80 +31,15 @@ export class StartHeadcount extends BaseCommand {
     public async run(ctx: ICommandContext): Promise<number> {
         ctx.guildDoc = await DungeonUtilities.fixDungeons(ctx.guildDoc!, ctx.guild!)!;
         await ctx.interaction.deferReply();
-        const location = ctx.interaction.options.getString("location");
         const allSections = MongoManager.getAllSections(ctx.guildDoc!);
+        const allRolePerms = MongoManager.getAllConfiguredRoles(ctx.guildDoc!);
 
         // Step 1: Find all sections that the leader can lead in.
-        const availableSections: DungeonSelectionType[] = [];
-
-        // Get all sections that the member can lead in
-        const allRolePerms = MongoManager.getAllConfiguredRoles(ctx.guildDoc!);
-        for (const section of allSections) {
-            if (!canManageRaidsIn(section, ctx.member!, ctx.guildDoc!))
-                continue;
-
-            const dungeons: IDungeonInfo[] = [];
-            const omittedDungeons: IDungeonInfo[] = [];
-            section.otherMajorConfig.afkCheckProperties.allowedDungeons.forEach(id => {
-                if (DungeonUtilities.isCustomDungeon(id)) {
-                    const customDgn = ctx.guildDoc!.properties.customDungeons.find(x => x.codeName === id);
-                    if (customDgn) {
-                        if (!hasPermsToRaid(customDgn.roleRequirement, ctx.member!, allRolePerms)) {
-                            omittedDungeons.push(customDgn);
-                            return;
-                        }
-
-                        dungeons.push(customDgn);
-                    }
-
-                    return;
-                }
-
-                const dgn = DUNGEON_DATA.find(x => x.codeName === id);
-                if (!dgn)
-                    return;
-
-                const overrideInfo = ctx.guildDoc!.properties.dungeonOverride.find(x => x.codeName === id);
-                if (!hasPermsToRaid(overrideInfo?.roleRequirement, ctx.member!, allRolePerms)) {
-                    omittedDungeons.push(dgn);
-                    return;
-                }
-
-                dungeons.push(dgn);
-                return;
-            });
-
-            if (dungeons.length === 0)
-                continue;
-
-            const afkCheckChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
-                ctx.guild!,
-                section.channels.raids.afkCheckChannelId
-            )!;
-
-            const controlPanelChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
-                ctx.guild!,
-                section.channels.raids.controlPanelChannelId
-            )!;
-
-            const verifiedRole = GuildFgrUtilities.getCachedRole(
-                ctx.guild!,
-                section.roles.verifiedRoleId
-            )!;
-
-            availableSections.push({
-                section: section,
-                cpChan: controlPanelChan,
-                afkCheckChan: afkCheckChan,
-                raiderRole: verifiedRole,
-                dungeons: dungeons,
-                omittedDungeons: omittedDungeons
-            });
-        }
+        const availableSections = await getAvailableSections(ctx, allRolePerms, allSections);
 
         if (availableSections.length === 0) {
             await ctx.interaction.editReply({
-                content: "You cannot start a headcount in any sections. Please make sure you have the appropriate"
+                content: "You cannot start a raid in any sections. Please make sure you have the appropriate"
                     + " permissions and that the section in particular has a configured AFK Check channel, control"
                     + " panel channel, and section verified role."
             });
@@ -136,56 +48,8 @@ export class StartHeadcount extends BaseCommand {
         }
 
         // Step 2: Ask for the appropriate section.
-        const sectionToUse: DungeonSelectionType | null = await new Promise(async (resolve) => {
-            if (availableSections.length === 1)
-                return resolve(availableSections[0]);
-
-            const identifier = StringUtil.generateRandomString(20);
-            const selectMenu = new MessageSelectMenu()
-                .setCustomId(identifier)
-                .setMaxValues(1)
-                .setMinValues(1);
-
-            selectMenu.addOptions([
-                {
-                    description: "Cancels the section selection menu",
-                    label: "Cancel.",
-                    value: "cancel"
-                },
-                ...availableSections.map(x => {
-                    return {
-                        description: `AFK Channel Channel: ${x.afkCheckChan.name}`,
-                        label: x.section.sectionName,
-                        value: x.section.uniqueIdentifier
-                    };
-                })
-            ]);
-
-            await ctx.interaction.editReply({
-                content: "Please select the section that you want to start your headcount in. You have a minute and a"
-                    + " half to choose. If you do not want to start a raid at this time, select the **Cancel** option.",
-                components: [new MessageActionRow().addComponents(selectMenu)]
-            });
-
-            const res = await AdvancedCollector.startInteractionEphemeralCollector({
-                targetAuthor: ctx.user,
-                acknowledgeImmediately: false,
-                targetChannel: ctx.channel,
-                duration:  60 * 1000
-            }, identifier);
-
-            if (!res || !res.isSelectMenu()) {
-                return resolve(null);
-            }
-
-            if (res.values[0] === "cancel") {
-                return resolve(null);
-            }
-
-            await res.deferUpdate();
-            return resolve(availableSections.find(x => x.section.uniqueIdentifier === res.values[0])!);
-        });
-
+        const sectionToUse: DungeonSelectionType | null = await getSelectedSection(ctx, availableSections);
+        
         if (!sectionToUse) {
             await ctx.interaction.editReply({
                 content: "This process has been canceled.",
@@ -195,78 +59,18 @@ export class StartHeadcount extends BaseCommand {
         }
 
         // Step 3: Ask for the appropriate dungeon
-        const uIdentifier = StringUtil.generateRandomString(20);
-        const selectMenus: MessageSelectMenu[] = [];
-        const dungeonSubset = ArrayUtilities.breakArrayIntoSubsets(sectionToUse.dungeons, 25);
-        for (let i = 0; i < Math.min(4, dungeonSubset.length); i++) {
-            selectMenus.push(
-                new MessageSelectMenu()
-                    .setCustomId(`${uIdentifier}_${i}`)
-                    .setMinValues(1)
-                    .setMaxValues(1)
-                    .addOptions(dungeonSubset[i].map(x => {
-                        return {
-                            label: x.dungeonName,
-                            value: x.codeName,
-                            emoji: x.portalEmojiId
-                        };
-                    }))
-            );
-        }
+        const selectedDgn = await getSelectedDungeon(ctx, sectionToUse);
 
-        const askDgnEmbed = MessageUtilities.generateBlankEmbed(ctx.member!, "GOLD")
-            .setTitle(`${sectionToUse.section.sectionName}: Select Dungeon`)
-            .setDescription("Please select a dungeon from the dropdown menu(s) below. If you want to cancel this,"
-                + " press the **Cancel** button.")
-            .setFooter({text: "You have 1 minute and 30 seconds to select a dungeon."})
-            .setTimestamp();
-
-        if (sectionToUse.omittedDungeons.length > 0) {
-            askDgnEmbed.addField(
-                "Omitted Dungeon",
-                "You are not able to start a headcount in the following dungeons due to not having the necessary"
-                + " role(s)." + StringUtil.codifyString(
-                    sectionToUse.omittedDungeons
-                        .map(x => `- ${x.dungeonName} (${x.isBuiltIn ? "Built-In" : "Custom"})`)
-                        .join("\n")
-                )
-            );
-        }
-
-        if (dungeonSubset.length > 4) {
-            askDgnEmbed.addField(
-                "Warning",
-                "Some dungeons have been excluded from the dropdown. This is due to a Discord limitation. To fix "
-                + "this issue, please ask a higher-up to exclude some irrelevant dungeons from this list."
-            );
-        }
-
-        await ctx.interaction.editReply({
-            embeds: [askDgnEmbed],
-            components: AdvancedCollector.getActionRowsFromComponents([
-                ...selectMenus,
-                ButtonConstants.CANCEL_BUTTON
-            ])
-        });
-
-        const selectedDgn = await AdvancedCollector.startInteractionEphemeralCollector({
-            targetAuthor: ctx.user,
-            acknowledgeImmediately: false,
-            targetChannel: ctx.channel,
-            duration: 1.5 * 60 * 1000
-        }, uIdentifier);
-
-        if (!selectedDgn || !selectedDgn.isSelectMenu()) {
+        if(!selectedDgn){
             await ctx.interaction.editReply({
                 components: [],
                 content: "You either did not select a dungeon in time or canceled this process.",
                 embeds: []
             });
-
             return 0;
         }
-
         const dungeonToUse = sectionToUse.dungeons.find(x => x.codeName === selectedDgn.values[0])!;
+
 
         // Step 4: Start it
         const hc = HeadcountInstance.new(ctx.member!, ctx.guildDoc!, sectionToUse.section, dungeonToUse);

--- a/src/commands/raid-leaders/StartHeadcount.ts
+++ b/src/commands/raid-leaders/StartHeadcount.ts
@@ -1,7 +1,7 @@
 import {BaseCommand, ICommandContext} from "../BaseCommand";
 import {MongoManager} from "../../managers/MongoManager";
 import {DungeonUtilities} from "../../utilities/DungeonUtilities";
-import {getAvailableSections, DungeonSelectionType, getSelectedSection, getSelectedDungeon} from "../../instances/Common";
+import {getAvailableSections, DungeonSelectionType, getSelectedSection, getSelectedDungeon} from "./common/RaidLeaderCommon";
 import {HeadcountInstance} from "../../instances/HeadcountInstance";
 
 export class StartHeadcount extends BaseCommand {

--- a/src/commands/raid-leaders/common/RaidLeaderCommon.ts
+++ b/src/commands/raid-leaders/common/RaidLeaderCommon.ts
@@ -1,0 +1,268 @@
+import {
+    Collection,
+    TextChannel,
+    Role,
+    MessageSelectMenu, MessageActionRow,
+} from "discord.js"
+import {
+    ISectionInfo,
+    IDungeonInfo,
+} from "../../../definitions"
+import { DefinedRole } from "../../../definitions/Types";
+import {
+    canManageRaidsIn,
+    hasPermsToRaid,
+} from "../../../instances/Common";
+import { ICommandContext } from "../../../commands";
+import { DUNGEON_DATA } from "../../../constants/dungeons/DungeonData";
+import { DungeonUtilities } from "../../../utilities/DungeonUtilities";
+import { ArrayUtilities } from "../../../utilities/ArrayUtilities";
+import { MessageUtilities } from "../../../utilities/MessageUtilities";
+import { ButtonConstants } from "../../../constants/ButtonConstants";
+import { GuildFgrUtilities } from "../../../utilities/fetch-get-request/GuildFgrUtilities";
+import { StringUtil } from "../../../utilities/StringUtilities";
+import { AdvancedCollector } from "../../../utilities/collectors/AdvancedCollector";
+
+
+export type DungeonSelectionType = {
+    section: ISectionInfo;
+    afkCheckChan: TextChannel;
+    cpChan: TextChannel;
+    raiderRole: Role;
+    dungeons: IDungeonInfo[];
+    omittedDungeons: IDungeonInfo[];
+};
+
+/**
+ * Checks all the sections a raider can lead in.
+ * @param {ICommandContext} ctx The command context.
+ * @param {Collection<DefinedRole, string[]>} allRolePerms The role collection.
+ * @param {ISectionInfo[]>} allSections All Guild Sections.
+ * @return {DungeonSelectionType[]} All sections the leader can lead in.
+ */
+ export async function getAvailableSections(ctx: ICommandContext, allRolePerms: Collection<DefinedRole, string[]>,
+    allSections: ISectionInfo[]){
+    
+    const availableSections: DungeonSelectionType[] = [];
+    for (const section of allSections) {
+        if (!canManageRaidsIn(section, ctx.member!, ctx.guildDoc!))
+            continue;
+
+        const dungeons: IDungeonInfo[] = [];
+        const omittedDungeons: IDungeonInfo[] = [];
+        section.otherMajorConfig.afkCheckProperties.allowedDungeons.forEach(id => {
+            if (DungeonUtilities.isCustomDungeon(id)) {
+                const customDgn = ctx.guildDoc!.properties.customDungeons.find(x => x.codeName === id);
+                if (customDgn) {
+                    if (!hasPermsToRaid(customDgn.roleRequirement, ctx.member!, allRolePerms)) {
+                        omittedDungeons.push(customDgn);
+                        return;
+                    }
+
+                    dungeons.push(customDgn);
+                }
+
+                return;
+            }
+
+            const dgn = DUNGEON_DATA.find(x => x.codeName === id);
+            if (!dgn)
+                return;
+
+            const overrideInfo = ctx.guildDoc!.properties.dungeonOverride.find(x => x.codeName === id);
+            if (!hasPermsToRaid(overrideInfo?.roleRequirement, ctx.member!, allRolePerms)) {
+                omittedDungeons.push(dgn);
+                return;
+            }
+
+            dungeons.push(dgn);
+            return;
+        });
+
+        if (dungeons.length === 0)
+            continue;
+
+        const afkCheckChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
+            ctx.guild!,
+            section.channels.raids.afkCheckChannelId
+        )!;
+
+        const controlPanelChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
+            ctx.guild!,
+            section.channels.raids.controlPanelChannelId
+        )!;
+
+        const verifiedRole = GuildFgrUtilities.getCachedRole(
+            ctx.guild!,
+            section.roles.verifiedRoleId
+        )!;
+
+        availableSections.push({
+            section: section,
+            cpChan: controlPanelChan,
+            afkCheckChan: afkCheckChan,
+            raiderRole: verifiedRole,
+            dungeons: dungeons,
+            omittedDungeons: omittedDungeons
+        });
+    }
+    return availableSections;
+}
+
+/**
+ * Prompts leader to select a section to use.
+ * @param {ICommandContext} ctx The command context.
+ * @param {DungeonSelectionType[]} availableSections The available sections.
+ * @return {DungeonSelectionType | null} A section or null.
+ */
+export async function getSelectedSection(ctx: ICommandContext, availableSections: DungeonSelectionType[]){
+    const sectionToUse: DungeonSelectionType | null = await new Promise(async (resolve) => {
+        if (availableSections.length === 1)
+            return resolve(availableSections[0]);
+
+        const identifier = StringUtil.generateRandomString(20);
+        const selectMenu = new MessageSelectMenu()
+            .setCustomId(identifier)
+            .setMaxValues(1)
+            .setMinValues(1);
+
+        selectMenu.addOptions([
+            {
+                description: "Cancels the section selection menu",
+                label: "Cancel.",
+                value: "cancel"
+            },
+            ...availableSections.map(x => {
+                return {
+                    description: `AFK Channel Channel: ${x.afkCheckChan.name}`,
+                    label: x.section.sectionName,
+                    value: x.section.uniqueIdentifier
+                };
+            })
+        ]);
+
+        await ctx.interaction.editReply({
+            content: "Please select the section that you want to start your raid in. You have a minute and a"
+                + " half to choose. If you do not want to start a raid at this time, select the **Cancel** option.",
+            components: [new MessageActionRow().addComponents(selectMenu)]
+        });
+
+        const res = await AdvancedCollector.startInteractionEphemeralCollector({
+            targetAuthor: ctx.user,
+            acknowledgeImmediately: false,
+            targetChannel: ctx.channel,
+            duration: 1.5 * 60 * 1000
+        }, identifier);
+
+        if (!res || !res.isSelectMenu()) {
+            return resolve(null);
+        }
+
+        if (res.values[0] === "cancel") {
+            return resolve(null);
+        }
+
+        await res.deferUpdate();
+        return resolve(availableSections.find(x => x.section.uniqueIdentifier === res.values[0])!);
+    });
+    return sectionToUse;
+}
+
+/**
+ * Prompts leader to select a dungeon to use.
+ * @param {ICommandContext} ctx The command context.
+ * @param {DungeonSelectionType[]} sectionToUse The section to use.
+ * @return {DungeonSelectionType | null} A dungeon selection or null.
+ */
+export async function getSelectedDungeon(ctx: ICommandContext, sectionToUse: DungeonSelectionType){
+    const uIdentifier = StringUtil.generateRandomString(20);
+    const selectMenus: MessageSelectMenu[] = [];
+
+    let exaltDungeons = [];
+    for(let i = 0; i < sectionToUse.dungeons.length; i++){
+        if(sectionToUse.dungeons[i].dungeonCategory === "Exaltation Dungeons"){
+            exaltDungeons.push(sectionToUse.dungeons[i]);
+        }
+    }
+    selectMenus.push(
+        new MessageSelectMenu()
+            .setCustomId(`${uIdentifier}_${5}`)
+            .setMinValues(1)
+            .setMaxValues(1)
+            .setPlaceholder("Exaltation Dungeons")
+            .addOptions(exaltDungeons.map(x => {
+                return {
+                    label: x.dungeonName,
+                    value: x.codeName,
+                    emoji: x.portalEmojiId
+                };
+            }))
+    );
+    
+    const dungeonSubset = ArrayUtilities.breakArrayIntoSubsets(sectionToUse.dungeons, 25);
+    for (let i = 0; i < Math.min(4, dungeonSubset.length); i++) {
+        selectMenus.push(
+            new MessageSelectMenu()
+                .setCustomId(`${uIdentifier}_${i}`)
+                .setMinValues(1)
+                .setMaxValues(1)
+                .setPlaceholder("All Dungeons " + (i+1))
+                .addOptions(dungeonSubset[i].map(x => {
+                    return {
+                        label: x.dungeonName,
+                        value: x.codeName,
+                        emoji: x.portalEmojiId
+                    };
+                }))
+        );
+    }
+
+    const askDgnEmbed = MessageUtilities.generateBlankEmbed(ctx.member!, "GOLD")
+        .setTitle(`${sectionToUse.section.sectionName}: Select Dungeon`)
+        .setDescription("Please select a dungeon from the dropdown menu(s) below. If you want to cancel this,"
+            + " press the **Cancel** button.")
+        .setFooter({text: "You have 1 minute and 30 seconds to select a dungeon."})
+        .setTimestamp();
+
+    if (sectionToUse.omittedDungeons.length > 0) {
+        askDgnEmbed.addField(
+            "Omitted Dungeon",
+            "You are not able to lead in the following dungeons due to not having the necessary role(s)."
+            + StringUtil.codifyString(
+                sectionToUse.omittedDungeons
+                    .map(x => `- ${x.dungeonName} (${x.isBuiltIn ? "Built-In" : "Custom"})`)
+                    .join("\n")
+            )
+        );
+    }
+
+    if (dungeonSubset.length > 4) {
+        askDgnEmbed.addField(
+            "Warning",
+            "Some dungeons have been excluded from the dropdown. This is due to a Discord limitation. To fix "
+            + "this issue, please ask a higher-up to exclude some irrelevant dungeons from this list."
+        );
+    }
+
+    await ctx.interaction.editReply({
+        embeds: [askDgnEmbed],
+        components: AdvancedCollector.getActionRowsFromComponents([
+            ...selectMenus,
+            AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
+                .setCustomId(`${uIdentifier}_cancel`)
+        ])
+    });
+
+    const selectedDgn = await AdvancedCollector.startInteractionEphemeralCollector({
+        targetAuthor: ctx.user,
+        acknowledgeImmediately: false,
+        targetChannel: ctx.channel,
+        duration: 1.5 * 60 * 1000
+    }, uIdentifier);
+
+    if (!selectedDgn || !selectedDgn.isSelectMenu()) {
+        return null;
+    }
+
+    return selectedDgn;
+}

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -3,10 +3,8 @@ import {
     Collection, CollectorFilter,
     EmojiIdentifierResolvable, Guild, GuildMember,
     MessageButton,
-    Role,
     MessageComponentInteraction,
     MessageSelectMenu,
-    MessageActionRow,
     TextChannel
 } from "discord.js";
 import {
@@ -24,14 +22,9 @@ import {HIGHEST_MODIFIER_LEVEL} from "../constants/dungeons/DungeonModifiers";
 import {StringBuilder} from "../utilities/StringBuilder";
 import {MAPPED_AFK_CHECK_REACTIONS} from "../constants/dungeons/MappedAfkCheckReactions";
 import {GlobalFgrUtilities} from "../utilities/fetch-get-request/GlobalFgrUtilities";
-import {ICommandContext, StartAfkCheck} from "../commands";
+import {StartAfkCheck} from "../commands";
 import {DefinedRole} from "../definitions/Types";
 import {MiscUtilities} from "../utilities/MiscUtilities";
-import {DungeonUtilities} from "../utilities/DungeonUtilities";
-import {DUNGEON_DATA} from "../constants/dungeons/DungeonData";
-import {ArrayUtilities} from "../utilities/ArrayUtilities";
-import {MessageUtilities} from "../utilities/MessageUtilities";
-import {ButtonConstants} from "../constants/ButtonConstants";
 
 
 export type ReactionInfoMore = IReactionInfo & {
@@ -39,16 +32,6 @@ export type ReactionInfoMore = IReactionInfo & {
     isCustomReaction: boolean;
     builtInEmoji?: EmojiIdentifierResolvable;
 };
-
-export type DungeonSelectionType = {
-    section: ISectionInfo;
-    afkCheckChan: TextChannel;
-    cpChan: TextChannel;
-    raiderRole: Role;
-    dungeons: IDungeonInfo[];
-    omittedDungeons: IDungeonInfo[];
-};
-
 export interface IKeyReactInfo {
     mapKey: keyof IMappedAfkCheckReactions;
     modifiers: string[];
@@ -544,238 +527,4 @@ export function hasPermsToRaid(roleReqs: string[] | undefined, member: GuildMemb
     }
 
     return false;
-}
-
-/**
- * Checks all the sections a raider can lead in.
- * @param {ICommandContext} ctx The command context.
- * @param {Collection<DefinedRole, string[]>} allRolePerms The role collection.
- * @param {ISectionInfo[]>} allSections All Guild Sections.
- * @return {DungeonSelectionType[]} All sections the leader can lead in.
- */
-export async function getAvailableSections(ctx: ICommandContext, allRolePerms: Collection<DefinedRole, string[]>,
-    allSections: ISectionInfo[]){
-    
-    const availableSections: DungeonSelectionType[] = [];
-    for (const section of allSections) {
-        if (!canManageRaidsIn(section, ctx.member!, ctx.guildDoc!))
-            continue;
-
-        const dungeons: IDungeonInfo[] = [];
-        const omittedDungeons: IDungeonInfo[] = [];
-        section.otherMajorConfig.afkCheckProperties.allowedDungeons.forEach(id => {
-            if (DungeonUtilities.isCustomDungeon(id)) {
-                const customDgn = ctx.guildDoc!.properties.customDungeons.find(x => x.codeName === id);
-                if (customDgn) {
-                    if (!hasPermsToRaid(customDgn.roleRequirement, ctx.member!, allRolePerms)) {
-                        omittedDungeons.push(customDgn);
-                        return;
-                    }
-
-                    dungeons.push(customDgn);
-                }
-
-                return;
-            }
-
-            const dgn = DUNGEON_DATA.find(x => x.codeName === id);
-            if (!dgn)
-                return;
-
-            const overrideInfo = ctx.guildDoc!.properties.dungeonOverride.find(x => x.codeName === id);
-            if (!hasPermsToRaid(overrideInfo?.roleRequirement, ctx.member!, allRolePerms)) {
-                omittedDungeons.push(dgn);
-                return;
-            }
-
-            dungeons.push(dgn);
-            return;
-        });
-
-        if (dungeons.length === 0)
-            continue;
-
-        const afkCheckChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
-            ctx.guild!,
-            section.channels.raids.afkCheckChannelId
-        )!;
-
-        const controlPanelChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
-            ctx.guild!,
-            section.channels.raids.controlPanelChannelId
-        )!;
-
-        const verifiedRole = GuildFgrUtilities.getCachedRole(
-            ctx.guild!,
-            section.roles.verifiedRoleId
-        )!;
-
-        availableSections.push({
-            section: section,
-            cpChan: controlPanelChan,
-            afkCheckChan: afkCheckChan,
-            raiderRole: verifiedRole,
-            dungeons: dungeons,
-            omittedDungeons: omittedDungeons
-        });
-    }
-    return availableSections;
-}
-
-/**
- * Prompts leader to select a section to use.
- * @param {ICommandContext} ctx The command context.
- * @param {DungeonSelectionType[]} availableSections The available sections.
- * @return {DungeonSelectionType | null} A section or null.
- */
-export async function getSelectedSection(ctx: ICommandContext, availableSections: DungeonSelectionType[]){
-    const sectionToUse: DungeonSelectionType | null = await new Promise(async (resolve) => {
-        if (availableSections.length === 1)
-            return resolve(availableSections[0]);
-
-        const identifier = StringUtil.generateRandomString(20);
-        const selectMenu = new MessageSelectMenu()
-            .setCustomId(identifier)
-            .setMaxValues(1)
-            .setMinValues(1);
-
-        selectMenu.addOptions([
-            {
-                description: "Cancels the section selection menu",
-                label: "Cancel.",
-                value: "cancel"
-            },
-            ...availableSections.map(x => {
-                return {
-                    description: `AFK Channel Channel: ${x.afkCheckChan.name}`,
-                    label: x.section.sectionName,
-                    value: x.section.uniqueIdentifier
-                };
-            })
-        ]);
-
-        await ctx.interaction.editReply({
-            content: "Please select the section that you want to start your raid in. You have a minute and a"
-                + " half to choose. If you do not want to start a raid at this time, select the **Cancel** option.",
-            components: [new MessageActionRow().addComponents(selectMenu)]
-        });
-
-        const res = await AdvancedCollector.startInteractionEphemeralCollector({
-            targetAuthor: ctx.user,
-            acknowledgeImmediately: false,
-            targetChannel: ctx.channel,
-            duration: 1.5 * 60 * 1000
-        }, identifier);
-
-        if (!res || !res.isSelectMenu()) {
-            return resolve(null);
-        }
-
-        if (res.values[0] === "cancel") {
-            return resolve(null);
-        }
-
-        await res.deferUpdate();
-        return resolve(availableSections.find(x => x.section.uniqueIdentifier === res.values[0])!);
-    });
-    return sectionToUse;
-}
-
-/**
- * Prompts leader to select a dungeon to use.
- * @param {ICommandContext} ctx The command context.
- * @param {DungeonSelectionType[]} sectionToUse The section to use.
- * @return {DungeonSelectionType | null} A dungeon selection or null.
- */
-export async function getSelectedDungeon(ctx: ICommandContext, sectionToUse: DungeonSelectionType){
-    const uIdentifier = StringUtil.generateRandomString(20);
-    const selectMenus: MessageSelectMenu[] = [];
-
-    let exaltDungeons = [];
-    for(let i = 0; i < sectionToUse.dungeons.length; i++){
-        if(sectionToUse.dungeons[i].dungeonCategory === "Exaltation Dungeons"){
-            exaltDungeons.push(sectionToUse.dungeons[i]);
-        }
-    }
-    selectMenus.push(
-        new MessageSelectMenu()
-            .setCustomId(`${uIdentifier}_${5}`)
-            .setMinValues(1)
-            .setMaxValues(1)
-            .setPlaceholder("Exaltation Dungeons")
-            .addOptions(exaltDungeons.map(x => {
-                return {
-                    label: x.dungeonName,
-                    value: x.codeName,
-                    emoji: x.portalEmojiId
-                };
-            }))
-    );
-    
-    const dungeonSubset = ArrayUtilities.breakArrayIntoSubsets(sectionToUse.dungeons, 25);
-    for (let i = 0; i < Math.min(4, dungeonSubset.length); i++) {
-        selectMenus.push(
-            new MessageSelectMenu()
-                .setCustomId(`${uIdentifier}_${i}`)
-                .setMinValues(1)
-                .setMaxValues(1)
-                .setPlaceholder("All Dungeons " + (i+1))
-                .addOptions(dungeonSubset[i].map(x => {
-                    return {
-                        label: x.dungeonName,
-                        value: x.codeName,
-                        emoji: x.portalEmojiId
-                    };
-                }))
-        );
-    }
-
-    const askDgnEmbed = MessageUtilities.generateBlankEmbed(ctx.member!, "GOLD")
-        .setTitle(`${sectionToUse.section.sectionName}: Select Dungeon`)
-        .setDescription("Please select a dungeon from the dropdown menu(s) below. If you want to cancel this,"
-            + " press the **Cancel** button.")
-        .setFooter({text: "You have 1 minute and 30 seconds to select a dungeon."})
-        .setTimestamp();
-
-    if (sectionToUse.omittedDungeons.length > 0) {
-        askDgnEmbed.addField(
-            "Omitted Dungeon",
-            "You are not able to lead in the following dungeons due to not having the necessary role(s)."
-            + StringUtil.codifyString(
-                sectionToUse.omittedDungeons
-                    .map(x => `- ${x.dungeonName} (${x.isBuiltIn ? "Built-In" : "Custom"})`)
-                    .join("\n")
-            )
-        );
-    }
-
-    if (dungeonSubset.length > 4) {
-        askDgnEmbed.addField(
-            "Warning",
-            "Some dungeons have been excluded from the dropdown. This is due to a Discord limitation. To fix "
-            + "this issue, please ask a higher-up to exclude some irrelevant dungeons from this list."
-        );
-    }
-
-    await ctx.interaction.editReply({
-        embeds: [askDgnEmbed],
-        components: AdvancedCollector.getActionRowsFromComponents([
-            ...selectMenus,
-            AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
-                .setCustomId(`${uIdentifier}_cancel`)
-        ])
-    });
-
-    const selectedDgn = await AdvancedCollector.startInteractionEphemeralCollector({
-        targetAuthor: ctx.user,
-        acknowledgeImmediately: false,
-        targetChannel: ctx.channel,
-        duration: 1.5 * 60 * 1000
-    }, uIdentifier);
-
-    if (!selectedDgn || !selectedDgn.isSelectMenu()) {
-        return null;
-    }
-
-    return selectedDgn;
 }

--- a/src/instances/Common.ts
+++ b/src/instances/Common.ts
@@ -3,8 +3,10 @@ import {
     Collection, CollectorFilter,
     EmojiIdentifierResolvable, Guild, GuildMember,
     MessageButton,
+    Role,
     MessageComponentInteraction,
     MessageSelectMenu,
+    MessageActionRow,
     TextChannel
 } from "discord.js";
 import {
@@ -22,14 +24,29 @@ import {HIGHEST_MODIFIER_LEVEL} from "../constants/dungeons/DungeonModifiers";
 import {StringBuilder} from "../utilities/StringBuilder";
 import {MAPPED_AFK_CHECK_REACTIONS} from "../constants/dungeons/MappedAfkCheckReactions";
 import {GlobalFgrUtilities} from "../utilities/fetch-get-request/GlobalFgrUtilities";
-import {StartAfkCheck} from "../commands";
+import {ICommandContext, StartAfkCheck} from "../commands";
 import {DefinedRole} from "../definitions/Types";
 import {MiscUtilities} from "../utilities/MiscUtilities";
+import {DungeonUtilities} from "../utilities/DungeonUtilities";
+import {DUNGEON_DATA} from "../constants/dungeons/DungeonData";
+import {ArrayUtilities} from "../utilities/ArrayUtilities";
+import {MessageUtilities} from "../utilities/MessageUtilities";
+import {ButtonConstants} from "../constants/ButtonConstants";
+
 
 export type ReactionInfoMore = IReactionInfo & {
     earlyLocAmt: number;
     isCustomReaction: boolean;
     builtInEmoji?: EmojiIdentifierResolvable;
+};
+
+export type DungeonSelectionType = {
+    section: ISectionInfo;
+    afkCheckChan: TextChannel;
+    cpChan: TextChannel;
+    raiderRole: Role;
+    dungeons: IDungeonInfo[];
+    omittedDungeons: IDungeonInfo[];
 };
 
 export interface IKeyReactInfo {
@@ -527,4 +544,238 @@ export function hasPermsToRaid(roleReqs: string[] | undefined, member: GuildMemb
     }
 
     return false;
+}
+
+/**
+ * Checks all the sections a raider can lead in.
+ * @param {ICommandContext} ctx The command context.
+ * @param {Collection<DefinedRole, string[]>} allRolePerms The role collection.
+ * @param {ISectionInfo[]>} allSections All Guild Sections.
+ * @return {DungeonSelectionType[]} All sections the leader can lead in.
+ */
+export async function getAvailableSections(ctx: ICommandContext, allRolePerms: Collection<DefinedRole, string[]>,
+    allSections: ISectionInfo[]){
+    
+    const availableSections: DungeonSelectionType[] = [];
+    for (const section of allSections) {
+        if (!canManageRaidsIn(section, ctx.member!, ctx.guildDoc!))
+            continue;
+
+        const dungeons: IDungeonInfo[] = [];
+        const omittedDungeons: IDungeonInfo[] = [];
+        section.otherMajorConfig.afkCheckProperties.allowedDungeons.forEach(id => {
+            if (DungeonUtilities.isCustomDungeon(id)) {
+                const customDgn = ctx.guildDoc!.properties.customDungeons.find(x => x.codeName === id);
+                if (customDgn) {
+                    if (!hasPermsToRaid(customDgn.roleRequirement, ctx.member!, allRolePerms)) {
+                        omittedDungeons.push(customDgn);
+                        return;
+                    }
+
+                    dungeons.push(customDgn);
+                }
+
+                return;
+            }
+
+            const dgn = DUNGEON_DATA.find(x => x.codeName === id);
+            if (!dgn)
+                return;
+
+            const overrideInfo = ctx.guildDoc!.properties.dungeonOverride.find(x => x.codeName === id);
+            if (!hasPermsToRaid(overrideInfo?.roleRequirement, ctx.member!, allRolePerms)) {
+                omittedDungeons.push(dgn);
+                return;
+            }
+
+            dungeons.push(dgn);
+            return;
+        });
+
+        if (dungeons.length === 0)
+            continue;
+
+        const afkCheckChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
+            ctx.guild!,
+            section.channels.raids.afkCheckChannelId
+        )!;
+
+        const controlPanelChan = GuildFgrUtilities.getCachedChannel<TextChannel>(
+            ctx.guild!,
+            section.channels.raids.controlPanelChannelId
+        )!;
+
+        const verifiedRole = GuildFgrUtilities.getCachedRole(
+            ctx.guild!,
+            section.roles.verifiedRoleId
+        )!;
+
+        availableSections.push({
+            section: section,
+            cpChan: controlPanelChan,
+            afkCheckChan: afkCheckChan,
+            raiderRole: verifiedRole,
+            dungeons: dungeons,
+            omittedDungeons: omittedDungeons
+        });
+    }
+    return availableSections;
+}
+
+/**
+ * Prompts leader to select a section to use.
+ * @param {ICommandContext} ctx The command context.
+ * @param {DungeonSelectionType[]} availableSections The available sections.
+ * @return {DungeonSelectionType | null} A section or null.
+ */
+export async function getSelectedSection(ctx: ICommandContext, availableSections: DungeonSelectionType[]){
+    const sectionToUse: DungeonSelectionType | null = await new Promise(async (resolve) => {
+        if (availableSections.length === 1)
+            return resolve(availableSections[0]);
+
+        const identifier = StringUtil.generateRandomString(20);
+        const selectMenu = new MessageSelectMenu()
+            .setCustomId(identifier)
+            .setMaxValues(1)
+            .setMinValues(1);
+
+        selectMenu.addOptions([
+            {
+                description: "Cancels the section selection menu",
+                label: "Cancel.",
+                value: "cancel"
+            },
+            ...availableSections.map(x => {
+                return {
+                    description: `AFK Channel Channel: ${x.afkCheckChan.name}`,
+                    label: x.section.sectionName,
+                    value: x.section.uniqueIdentifier
+                };
+            })
+        ]);
+
+        await ctx.interaction.editReply({
+            content: "Please select the section that you want to start your raid in. You have a minute and a"
+                + " half to choose. If you do not want to start a raid at this time, select the **Cancel** option.",
+            components: [new MessageActionRow().addComponents(selectMenu)]
+        });
+
+        const res = await AdvancedCollector.startInteractionEphemeralCollector({
+            targetAuthor: ctx.user,
+            acknowledgeImmediately: false,
+            targetChannel: ctx.channel,
+            duration: 1.5 * 60 * 1000
+        }, identifier);
+
+        if (!res || !res.isSelectMenu()) {
+            return resolve(null);
+        }
+
+        if (res.values[0] === "cancel") {
+            return resolve(null);
+        }
+
+        await res.deferUpdate();
+        return resolve(availableSections.find(x => x.section.uniqueIdentifier === res.values[0])!);
+    });
+    return sectionToUse;
+}
+
+/**
+ * Prompts leader to select a dungeon to use.
+ * @param {ICommandContext} ctx The command context.
+ * @param {DungeonSelectionType[]} sectionToUse The section to use.
+ * @return {DungeonSelectionType | null} A dungeon selection or null.
+ */
+export async function getSelectedDungeon(ctx: ICommandContext, sectionToUse: DungeonSelectionType){
+    const uIdentifier = StringUtil.generateRandomString(20);
+    const selectMenus: MessageSelectMenu[] = [];
+
+    let exaltDungeons = [];
+    for(let i = 0; i < sectionToUse.dungeons.length; i++){
+        if(sectionToUse.dungeons[i].dungeonCategory === "Exaltation Dungeons"){
+            exaltDungeons.push(sectionToUse.dungeons[i]);
+        }
+    }
+    selectMenus.push(
+        new MessageSelectMenu()
+            .setCustomId(`${uIdentifier}_${5}`)
+            .setMinValues(1)
+            .setMaxValues(1)
+            .setPlaceholder("Exaltation Dungeons")
+            .addOptions(exaltDungeons.map(x => {
+                return {
+                    label: x.dungeonName,
+                    value: x.codeName,
+                    emoji: x.portalEmojiId
+                };
+            }))
+    );
+    
+    const dungeonSubset = ArrayUtilities.breakArrayIntoSubsets(sectionToUse.dungeons, 25);
+    for (let i = 0; i < Math.min(4, dungeonSubset.length); i++) {
+        selectMenus.push(
+            new MessageSelectMenu()
+                .setCustomId(`${uIdentifier}_${i}`)
+                .setMinValues(1)
+                .setMaxValues(1)
+                .setPlaceholder("All Dungeons " + (i+1))
+                .addOptions(dungeonSubset[i].map(x => {
+                    return {
+                        label: x.dungeonName,
+                        value: x.codeName,
+                        emoji: x.portalEmojiId
+                    };
+                }))
+        );
+    }
+
+    const askDgnEmbed = MessageUtilities.generateBlankEmbed(ctx.member!, "GOLD")
+        .setTitle(`${sectionToUse.section.sectionName}: Select Dungeon`)
+        .setDescription("Please select a dungeon from the dropdown menu(s) below. If you want to cancel this,"
+            + " press the **Cancel** button.")
+        .setFooter({text: "You have 1 minute and 30 seconds to select a dungeon."})
+        .setTimestamp();
+
+    if (sectionToUse.omittedDungeons.length > 0) {
+        askDgnEmbed.addField(
+            "Omitted Dungeon",
+            "You are not able to lead in the following dungeons due to not having the necessary role(s)."
+            + StringUtil.codifyString(
+                sectionToUse.omittedDungeons
+                    .map(x => `- ${x.dungeonName} (${x.isBuiltIn ? "Built-In" : "Custom"})`)
+                    .join("\n")
+            )
+        );
+    }
+
+    if (dungeonSubset.length > 4) {
+        askDgnEmbed.addField(
+            "Warning",
+            "Some dungeons have been excluded from the dropdown. This is due to a Discord limitation. To fix "
+            + "this issue, please ask a higher-up to exclude some irrelevant dungeons from this list."
+        );
+    }
+
+    await ctx.interaction.editReply({
+        embeds: [askDgnEmbed],
+        components: AdvancedCollector.getActionRowsFromComponents([
+            ...selectMenus,
+            AdvancedCollector.cloneButton(ButtonConstants.CANCEL_BUTTON)
+                .setCustomId(`${uIdentifier}_cancel`)
+        ])
+    });
+
+    const selectedDgn = await AdvancedCollector.startInteractionEphemeralCollector({
+        targetAuthor: ctx.user,
+        acknowledgeImmediately: false,
+        targetChannel: ctx.channel,
+        duration: 1.5 * 60 * 1000
+    }, uIdentifier);
+
+    if (!selectedDgn || !selectedDgn.isSelectMenu()) {
+        return null;
+    }
+
+    return selectedDgn;
 }


### PR DESCRIPTION
Refactored steps 1-3 in both StartHeadcount and StartAfkCheck into methods in Common.ts

Minor change: added specific dropdown for Exaltation Dungeons.

I recommend viewing changes in split mode rather than unified.